### PR TITLE
Refresh installation instructions and package metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,24 +10,23 @@
 
 ## Installation
 
-Before installing HueHunter, ensure you have Python installed on your system. HueHunter works best with Python 3.6 or newer.
+Before installing HueHunter, ensure you have Python installed on your system.
 
-To install HueHunter directly from the source:
+To install the current source version:
 
-1. First, clone the repository:
-   ```bash
-   git clone https://github.com/txhno/huehunter.git
-   ```
-2. Navigate to the `huehunter` directory:
-   ```bash
-   cd huehunter
-   ```
-3. Install the package:
-   ```bash
-   pip install .
-   ```
+```bash
+git clone https://github.com/txhno/huehunter.git
+cd huehunter
+python -m pip install .
+```
 
-This series of commands will download the HueHunter source, move you into the HueHunter project directory, and install HueHunter along with its dependencies directly from the source code. This method is particularly useful if you plan to modify the code or contribute to the project.
+If you want to install directly from GitHub without cloning the repository first:
+
+```bash
+python -m pip install git+https://github.com/txhno/huehunter.git
+```
+
+Both commands install HueHunter and its dependencies in one step.
 
 ## Dependencies
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,11 @@ setup(
             'huehunter=huehunter.huehunter:main',
         ],
     },
-    url='http://pypi.python.org/pypi/HueHunter/',
-    license='LICENSE.txt',
+    url='https://github.com/txhno/huehunter',
+    license='MIT',
     description='A tool that detects dominant colors in images.',
     long_description=open('README.md').read(),
+    long_description_content_type='text/markdown',
     install_requires=[
         "opencv-python-headless",
         "numpy",


### PR DESCRIPTION
## Summary
- simplify the README installation flow
- document direct installation from GitHub
- update the package URL and Markdown long description metadata

Closes #2

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to README installation guidance and `setup.py` package metadata, with no runtime logic impacted.
> 
> **Overview**
> Simplifies `README.md` installation instructions (switching to `python -m pip` and adding a direct `pip install git+...` option) and removes the verbose step-by-step clone/install text.
> 
> Updates `setup.py` metadata by pointing `url` at GitHub, setting the license to `MIT`, and declaring `long_description_content_type='text/markdown'` so the README renders correctly on package indexes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af02cf498d794d0a763f454ca90675d64ca17335. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->